### PR TITLE
bug

### DIFF
--- a/error.txt
+++ b/error.txt
@@ -1,0 +1,6 @@
+File "./theories/ReflectEq.v", line 74, characters 2-55:
+Error:
+Backtrace:
+
+Anomaly "print function not found for a value interpreted as tauto_flags."
+Please report at http://coq.inria.fr/bugs/.

--- a/utils/theories/MCArith.v
+++ b/utils/theories/MCArith.v
@@ -13,7 +13,10 @@ Proof.
   intros.
   destruct (Nat.leb_spec0 x y).
   now constructor.
-  constructor. now lia.
+  constructor.
+  Set Debug Off.
+  now lia.
+  Set Debug On.
 Qed.
 
 Lemma nat_rev_ind (max : nat) :

--- a/utils/theories/ReflectEq.v
+++ b/utils/theories/ReflectEq.v
@@ -1,4 +1,4 @@
-From Ltac2 Require Import Ltac2.
+(* From Ltac2 Require Import Ltac2. *)
 From Ltac2 Require Option.
 Set Ltac Debug.
 Set Ltac2 Backtrace.

--- a/utils/theories/canonicaltries/CanonicalTries.v
+++ b/utils/theories/canonicaltries/CanonicalTries.v
@@ -1,8 +1,9 @@
-From Ltac2 Require Import Ltac2.
-From Ltac2 Require Option.
+(* From Ltac2 Require Import Ltac2. *)
+ From Ltac2 Require Option. 
 Set Ltac Debug.
-Set Ltac2 Backtrace.
-Set Ltac Batch Debug.
+ Set Ltac2 Backtrace. 
+ Set Ltac Backtrace. 
+ Set Ltac Batch Debug. 
 (** * The extensional binary tries based on a canonical representation *)
 
 (* Authors: Andrew W. Appel, Princeton University,
@@ -208,7 +209,11 @@ Module PTree.
 
    Lemma gso0: forall {A} p q (x: A), p<>q -> get' p (set0 q x) = None.
    Proof.
-    induction p; destruct q; simpl; intros; auto; try apply IHp; congruence.
+
+     induction p; destruct q; simpl; intros; auto;
+       try apply IHp;
+       congruence.
+     Set Debug On.
    Qed.
 
    Theorem gss:


### PR DESCRIPTION
bug report for coq

File "./theories/ReflectEq.v", line 74\, characters 2-55:
Error:                                 Backtrace:

Anomaly "print function not found for \
a value interpreted as tauto_flags."
Please report at http://coq.inria.fr/b\
ugs/.